### PR TITLE
Match any kind of GPL license in Quality check

### DIFF
--- a/quality_modifiers.rb
+++ b/quality_modifiers.rb
@@ -74,7 +74,7 @@ class QualityModifiers
       }),
 
       Modifier.new("Uses GPL", "There are legal issues around distributing GPL'd code in App Store environments.", -20, Proc.new { |hash, stats, owners|
-        hash[:license_short_name] == "GPL 3" ||  hash[:license_short_name] == "LGPL 3"
+        hash[:license_short_name] =~ /GPL/i
       }),
 
       Modifier.new("Uses WTFPL", "WTFPL was denied as an OSI approved license. Thus it is not classed as code license.", -5, Proc.new { |hash, stats, owners|


### PR DESCRIPTION
This covers all the variants of GPL licenses like GPL 2/3, LGPL 2/3 and AGPL as well as all the possible variations and exceptions as you can see on http://spdx.org/licenses/

As discussed with @orta on twitter: https://twitter.com/orta/status/608691314922762240 :green_apple: 
