### PR TITLE
SPM support, and removed the negative QI for Jazzy 

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,7 +61,7 @@ class App < Sinatra::Base
     github_stats = github_pod_metrics.where(github_pod_metrics[:pod_id] => pod.id).first
     cocoapods_stats = stats_metrics.where(pod_id: pod.id).first
     owners = owners_pods.outer_join(:owners).on(:owner_id => :id).where(:pod_id => pod.id)
-    data[:quality_estimate] = QualityModifiers.new.generate(data, github_stats, cocoapods_stats, cp_stats, owners)
+    data[:quality_estimate] = QualityModifiers.new.generate(data, github_stats, cocoapods_stats, cocoapods_stats, owners)
 
     # update or create a metrics
     metric = cocoadocs_pod_metrics.where(cocoadocs_pod_metrics[:pod_id] => pod.id).first
@@ -108,6 +108,9 @@ class App < Sinatra::Base
     owners = owners_pods.outer_join(:owners).on(:owner_id => :id).where(:pod_id => pod.id)
     halt 404, "Owners for Pod not found." unless owners
 
+    cocoapods_stats = stats_metrics.where(pod_id: pod.id).first
+    # Don't 404 if this can't be found, it's not critical
+
     result = {
       base: {
         score: 50,
@@ -117,7 +120,7 @@ class App < Sinatra::Base
     }
 
     result[:metrics] = QualityModifiers.new.modifiers.map do |modifier|
-      modifier.to_json(metric, github_stats, cp_stats, owners)
+      modifier.to_json(metric, github_stats, cocoapods_stats, owners)
     end
 
     result.to_json

--- a/app.rb
+++ b/app.rb
@@ -55,6 +55,7 @@ class App < Sinatra::Base
       :dominant_language => metrics["dominant_language"],
       :is_vendored_framework => metrics["is_vendored_framework"],
       :builds_independently => metrics["builds_independently"],
+      :spm_support => metrics["spm_support"],
     }
 
     github_stats = github_pod_metrics.where(github_pod_metrics[:pod_id] => pod.id).first

--- a/app.rb
+++ b/app.rb
@@ -58,8 +58,9 @@ class App < Sinatra::Base
     }
 
     github_stats = github_pod_metrics.where(github_pod_metrics[:pod_id] => pod.id).first
+    cocoapods_stats = stats_metrics.where(pod_id: pod.id).first
     owners = owners_pods.outer_join(:owners).on(:owner_id => :id).where(:pod_id => pod.id)
-    data[:quality_estimate] = QualityModifiers.new.generate(data, github_stats, owners)
+    data[:quality_estimate] = QualityModifiers.new.generate(data, github_stats, cocoapods_stats, cp_stats, owners)
 
     # update or create a metrics
     metric = cocoadocs_pod_metrics.where(cocoadocs_pod_metrics[:pod_id] => pod.id).first
@@ -115,7 +116,7 @@ class App < Sinatra::Base
     }
 
     result[:metrics] = QualityModifiers.new.modifiers.map do |modifier|
-      modifier.to_json(metric, github_stats, owners)
+      modifier.to_json(metric, github_stats, cp_stats, owners)
     end
 
     result.to_json

--- a/domain.rb
+++ b/domain.rb
@@ -30,4 +30,5 @@ DB = Flounder.domain connection do |dom|
   #
   dom.entity :cocoadocs_pod_metrics, :cocoadocs_pod_metric, 'cocoadocs_pod_metrics'
   dom.entity :github_pod_metrics, :github_pod_metric, 'github_pod_metrics'
+  dom.entity :stats_metrics, :stat_metric, 'stats_metrics'
 end

--- a/quality_modifiers.rb
+++ b/quality_modifiers.rb
@@ -8,7 +8,7 @@ class Modifier
     @function = function
   end
 
-  def to_json(hash, pod_stats, cocoapods_stats, cp_stats, owners)
+  def to_json(hash, pod_stats, cp_stats, owners)
     {
       "title" => title,
       "description" => description,
@@ -70,6 +70,14 @@ class QualityModifiers
       }),
 
 # At the moment this is entirely focused on libraries that are coming from GitHub. In the future, once Stats for downloads/installs are mature then we will move over to that in order to accomodate libraries not using GitHub.
+
+### Swift Package Manager
+# We want to encourage support of Apple's Swift Package Manager, it's better for the community to be unified. For more information see our [FAQ](https://guides.cocoapods.org/using/faq.html).
+# This currently checks for the existence of `Package.swift`, once SPM development has slowed down, we may transistion to testing that it supports the latest release.
+
+      Modifier.new("Supports Swift Package Manager", "Supports Apple's official package manager for Swift.", 10, Proc.new { |hash, stats, cp_stats, owners|
+        hash[:spm_support]
+      }),
 
 ### Inline Documentation
 # A lot of the generated documentation comes from inside the library itself.
@@ -221,12 +229,6 @@ class QualityModifiers
 
       Modifier.new("Lots of open issues", "A project with a lot of open issues is generally abandoned. If it is a popular library, then it is usually offset by the popularity modifiers.", -8, Proc.new { |hash, stats, cp_stats, owners|
         stats[:open_issues].to_i > 50
-      }),
-
-# This metric checks for frameworks that are genererated when running `xcodebuild` within the downloaded repo. You need to turn on shared schemes for the framework in order for it to be registered.
-
-      Modifier.new("Independently builds through Xcode", "Meaning that the library can independently be built after a git clone.", 5, Proc.new { |hash, stats, cp_stats, owners|
-        hash[:builds_independently]
       })
 
       #### End of Markdown --->


### PR DESCRIPTION
Now that there's an official package manager, we should be politely pushing people in that direction. So I've removed the Carthage positive nudge, and made a more impactful one for SPM support. The Carthage one was unreliable, so it's nice for us to keep track of this stuff, but I'm not comfortable with us adding points against that.

When Xcode / Swift updates CD/Jazzy lag for a bit, and anyone who ships their libs right away get punished by the QIs cause they have a score of zero. So now we ship along `NSNotFound` instead from CD and the QI ignores it.
